### PR TITLE
updated ARI specs from latest releases of major versions

### DIFF
--- a/codegen/src/main/resources/codegen-data/ari_1_11_2/bridges.json
+++ b/codegen/src/main/resources/codegen-data/ari_1_11_2/bridges.json
@@ -26,7 +26,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media).",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_single).",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -65,7 +65,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media) to set.",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_single) to set.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,

--- a/codegen/src/main/resources/codegen-data/ari_4_1_3/bridges.json
+++ b/codegen/src/main/resources/codegen-data/ari_4_1_3/bridges.json
@@ -30,7 +30,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu).",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single).",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -69,7 +69,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu) to set.",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single) to set.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -746,7 +746,7 @@
 				},
 				"video_mode": {
 					"type": "string",
-					"description": "The video mode the bridge is using. One of 'none', 'talker', or 'single'.",
+					"description": "The video mode the bridge is using. One of 'none', 'talker', 'sfu', or 'single'.",
 					"required": false
 				},
 				"video_source_id": {

--- a/codegen/src/main/resources/codegen-data/ari_5_1_1/bridges.json
+++ b/codegen/src/main/resources/codegen-data/ari_5_1_1/bridges.json
@@ -30,7 +30,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu).",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single).",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -69,7 +69,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu) to set.",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single) to set.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -746,7 +746,7 @@
 				},
 				"video_mode": {
 					"type": "string",
-					"description": "The video mode the bridge is using. One of 'none', 'talker', or 'single'.",
+					"description": "The video mode the bridge is using. One of 'none', 'talker', 'sfu', or 'single'.",
 					"required": false
 				},
 				"video_source_id": {

--- a/codegen/src/main/resources/codegen-data/ari_6_0_0/bridges.json
+++ b/codegen/src/main/resources/codegen-data/ari_6_0_0/bridges.json
@@ -30,7 +30,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu).",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single).",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -69,7 +69,7 @@
 					"parameters": [
 						{
 							"name": "type",
-							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu) to set.",
+							"description": "Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media, video_sfu, video_single) to set.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -186,6 +186,15 @@
 						{
 							"name": "mute",
 							"description": "Mute audio from this channel, preventing it to pass through to the bridge",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "boolean",
+							"defaultValue": false
+						},
+						{
+							"name": "inhibitConnectedLineUpdates",
+							"description": "Do not present the identity of the newly connected channel to other bridge members",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -746,7 +755,7 @@
 				},
 				"video_mode": {
 					"type": "string",
-					"description": "The video mode the bridge is using. One of 'none', 'talker', or 'single'.",
+					"description": "The video mode the bridge is using. One of 'none', 'talker', 'sfu', or 'single'.",
 					"required": false
 				},
 				"video_source_id": {

--- a/codegen/src/main/resources/codegen-data/ari_6_0_0/channels.json
+++ b/codegen/src/main/resources/codegen-data/ari_6_0_0/channels.json
@@ -222,6 +222,14 @@
 							"required": false,
 							"allowMultiple": false,
 							"dataType": "string"
+						},
+						{
+							"name": "variables",
+							"description": "The \"variables\" key in the body object holds variable key/value pairs to set on the channel on creation. Other keys in the body object are interpreted as query parameters. Ex. { \"endpoint\": \"SIP/Alice\", \"variables\": { \"CALLERID(name)\": \"Alice\" } }",
+							"paramType": "body",
+							"required": false,
+							"dataType": "containers",
+							"allowMultiple": false
 						}
 					],
 					"errorResponses": [
@@ -1751,6 +1759,141 @@
 						{
 							"code": 404,
 							"reason": "Channel cannot be found."
+						}
+					]
+				}
+			]
+		},
+		{
+			"path": "/channels/externalMedia",
+			"description": "Create a channel to an External Media source/sink.",
+			"operations": [
+				{
+					"httpMethod": "POST",
+					"summary": "Start an External Media session.",
+					"notes": "Create a channel to an External Media source/sink.",
+					"nickname": "externalMedia",
+					"responseClass": "Channel",
+					"parameters": [
+						{
+							"name": "channelId",
+							"description": "The unique id to assign the channel on creation.",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "app",
+							"description": "Stasis Application to place channel into",
+							"paramType": "query",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "variables",
+							"description": "The \"variables\" key in the body object holds variable key/value pairs to set on the channel on creation. Other keys in the body object are interpreted as query parameters. Ex. { \"endpoint\": \"SIP/Alice\", \"variables\": { \"CALLERID(name)\": \"Alice\" } }",
+							"paramType": "body",
+							"required": false,
+							"dataType": "containers",
+							"allowMultiple": false
+						},
+						{
+							"name": "external_host",
+							"description": "Hostname/ip:port of external host",
+							"paramType": "query",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "encapsulation",
+							"description": "Payload encapsulation protocol",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string",
+							"defaultValue": "rtp",
+							"allowableValues": {
+								"valueType": "LIST",
+								"values": [
+									"rtp",
+									"audiosocket"
+								]
+							}
+						},
+						{
+							"name": "transport",
+							"description": "Transport protocol",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string",
+							"defaultValue": "udp",
+							"allowableValues": {
+								"valueType": "LIST",
+								"values": [
+									"udp",
+									"tcp"
+								]
+							}
+						},
+						{
+							"name": "connection_type",
+							"description": "Connection type (client/server)",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string",
+							"defaultValue": "client",
+							"allowableValues": {
+								"valueType": "LIST",
+								"values": [
+									"client"
+								]
+							}
+						},
+						{
+							"name": "format",
+							"description": "Format to encode audio in",
+							"paramType": "query",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "direction",
+							"description": "External media direction",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string",
+							"defaultValue": "both",
+							"allowableValues": {
+								"valueType": "LIST",
+								"values": [
+									"both"
+								]
+							}
+						},
+						{
+							"name": "data",
+							"description": "An arbitrary data field",
+							"paramType": "query",
+							"required": false,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					],
+					"errorResponses": [
+						{
+							"code": 400,
+							"reason": "Invalid parameters"
+						},
+						{
+							"code": 409,
+							"reason": "Channel is not in a Stasis application; Channel is already bridged"
 						}
 					]
 				}

--- a/codegen/src/main/resources/codegen-data/ari_6_0_0/endpoints.json
+++ b/codegen/src/main/resources/codegen-data/ari_6_0_0/endpoints.json
@@ -233,22 +233,6 @@
 				}
 			}
 		},
-		"TextMessageVariable": {
-			"id": "TextMessageVariable",
-			"description": "A key/value pair variable in a text message.",
-			"properties": {
-				"key": {
-					"type": "string",
-					"description": "A unique key identifying the variable.",
-					"required": true
-				},
-				"value": {
-					"type": "string",
-					"description": "The value of the variable.",
-					"required": true
-				}
-			}
-		},
 		"TextMessage": {
 			"id": "TextMessage",
 			"description": "A text message.",
@@ -269,8 +253,8 @@
 					"required": true
 				},
 				"variables": {
-					"type": "List[TextMessageVariable]",
-					"description": "Technology specific key/value pairs associated with the message.",
+					"type": "object",
+					"description": "Technology specific key/value pairs (JSON object) associated with the message.",
 					"required": false
 				}
 			}


### PR DESCRIPTION
Suggested fix for issue #174: add to `getApis.sh` the ability to extract the REST API specs from the latest release tarballs; update the local copy of the specs accordingly.